### PR TITLE
IE 6-9 Bug Fix

### DIFF
--- a/jquery.geokbd.js
+++ b/jquery.geokbd.js
@@ -76,7 +76,7 @@ $.fn.geokbd = function(options) {
 
 		if (ch != kach) {
 			if ($.browser.msie) {
-				window.event.keyCode = kaText.charCodeAt(0);
+				window.event.keyCode = kach.charCodeAt(0);
 			} else {
 				pasteTo.call(kach, e.target);
 				e.preventDefault();


### PR DESCRIPTION
79-ე ხაზზე katext-ის ნაცვლად, kach ცვლადი უნდა იყოს.. ამის გამო IE-ში ქართული კლავიატურა არ მუშაობდა : )
